### PR TITLE
Ignore from collections.abc

### DIFF
--- a/pylint_google_style_guide_imports_enforcing/__init__.py
+++ b/pylint_google_style_guide_imports_enforcing/__init__.py
@@ -20,7 +20,7 @@ class ModuleOnlyImports(BaseChecker):
 
     priority = -1
 
-    excluded_modules = ["typing", "typing_extensions", "six.moves", "__future__"]
+    excluded_modules = ["typing", "typing_extensions", "six.moves", "collections.abc", "__future__"]
 
     def visit_importfrom(self, node):
         imported = node.do_import_module()

--- a/pylint_google_style_guide_imports_enforcing/test_alphatically_sorted_imports_checker.py
+++ b/pylint_google_style_guide_imports_enforcing/test_alphatically_sorted_imports_checker.py
@@ -10,6 +10,7 @@ class TestAlphabeticallySortedImports(pylint.testutils.CheckerTestCase):
     def test_doesnt_report_direct_imports_from_excluded_modules(self):
         importnode = astroid.extract_node(
             """
+        from collections.abc import Mapping, Sequence
         from typing import Optional
         from os import path
         from typing_extensions import get_args


### PR DESCRIPTION
Not sure when this was added, but it seems like `collections.abc` is another one of the white-listed imports from the Google styleguide: https://google.github.io/styleguide/pyguide.html#2241-exemptions