### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [metadata]
-description-file = README.rst
+description_file = README.rst
 


### PR DESCRIPTION
I'm getting "setuptools.errors.InvalidConfigError: Invalid dash-separated key 'description-file' in 'metadata' (setup.cfg), please use the underscore name 'description_file' instead." when installing the plugin as a dependency, so let's update the dash to underscore.